### PR TITLE
Fix external link inconsistency

### DIFF
--- a/running-a-nats-service/nats_admin/profiling.md
+++ b/running-a-nats-service/nats_admin/profiling.md
@@ -2,7 +2,7 @@
 
 When investigating and debugging a performance issue with the NATS Server (i.e. unexpectedly high CPU or RAM utilisation), it may be necessary for you to collect and provide profiles from your deployment for troublshooting. These profiles are crucial to understand where CPU time and memory are being spent.
 
-Note that profiling is an advanced operation for development purposes only. Server operators should use the [monitoring port](/running-a-nats-service/nats_admin/monitoring) instead for monitoring day-to-day runtime statistics.
+Note that profiling is an advanced operation for development purposes only. Server operators should use the [monitoring port](../monitoring) instead for monitoring day-to-day runtime statistics.
 
 ### Via the NATS CLI
 


### PR DESCRIPTION
Once using redirection like **[monitoring port](/running-a-nats-service/nats_admin/monitoring)** within the same docs page, it will redirect to external source **https://github.com/nats-io/nats.docs/blob/master/running-a-nats-service/nats_admin/monitoring/README.md** while using **[monitoring port](../monitoring)** will redirect correctly within the same docs website.